### PR TITLE
provisioning: remove config encryption field

### DIFF
--- a/wazo_ui/plugins/provisioning/form.py
+++ b/wazo_ui/plugins/provisioning/form.py
@@ -59,7 +59,6 @@ class RawConfigDeviceForm(BaseForm):
         ('SIP', 'SIP'),
         ('SCCP', 'SCCP')
     ])
-    config_encryption_enabled = BooleanField(l_('Enabled encryption config file'), default=False)
     ntp_enabled = BooleanField(l_('Enabled NTP'), default=False)
     ntp_ip = StringField(l_('NTP server'), validators=[IPAddress])
     sip_dtmf_mode = SelectField(l_('SIP DTMF mode'), choices=[

--- a/wazo_ui/plugins/provisioning/templates/wazo_engine/provisioning/config_device/edit.html
+++ b/wazo_ui/plugins/provisioning/templates/wazo_engine/provisioning/config_device/edit.html
@@ -24,7 +24,6 @@
               {{ render_field(form.raw_config.form.locale) }}
               {{ render_field(form.raw_config.form.timezone) }}
               {{ render_field(form.raw_config.form.protocol) }}
-              {{ render_field(form.raw_config.form.config_encryption_enabled) }}
               {{ render_field(form.raw_config.form.ntp_enabled) }}
               {{ render_field(form.raw_config.form.ntp_ip) }}
               {{ render_field(form.raw_config.form.sip_dtmf_mode) }}

--- a/wazo_ui/plugins/provisioning/templates/wazo_engine/provisioning/config_device/list.html
+++ b/wazo_ui/plugins/provisioning/templates/wazo_engine/provisioning/config_device/list.html
@@ -29,7 +29,6 @@
           {{ render_field(form.raw_config.form.locale) }}
           {{ render_field(form.raw_config.form.timezone) }}
           {{ render_field(form.raw_config.form.protocol) }}
-          {{ render_field(form.raw_config.form.config_encryption_enabled) }}
           {{ render_field(form.raw_config.form.ntp_enabled) }}
           {{ render_field(form.raw_config.form.ntp_ip) }}
           {{ render_field(form.raw_config.form.sip_dtmf_mode) }}


### PR DESCRIPTION
reason: deprecated since 2013 (see wazo-provd-plugins commit
e0c73576649f0818bfdf4208f04aaf27330dd741)