### PR TITLE
directories: verify_certificate is optional

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ pyyaml==3.13  # from xivo-lib-python
 requests==2.21.0
 stevedore==1.29.0
 werkzeug==0.14.1
+wtforms==2.2.1

--- a/wazo_ui/plugins/dird_source/view.py
+++ b/wazo_ui/plugins/dird_source/view.py
@@ -259,7 +259,7 @@ class DirdSourceView(BaseIPBXHelperView):
 
         # Handle `verify_certificate` for office 365 or google that can be True, False or the value of certificate_path
         if backend in ('office365', 'google', 'conference', 'wazo'):
-            verify_certificate = resource[config_name]['auth']['verify_certificate']
+            verify_certificate = resource[config_name]['auth'].get('verify_certificate')
             if verify_certificate in (True, False):
                 verify = verify_certificate
             else:
@@ -269,7 +269,7 @@ class DirdSourceView(BaseIPBXHelperView):
             resource[config_name]['auth']['verify_certificate'] = verify
 
         if backend in ('conference', 'wazo'):
-            verify_certificate = resource[config_name]['confd']['verify_certificate']
+            verify_certificate = resource[config_name]['confd'].get('verify_certificate')
             if verify_certificate in (True, False):
                 verify = verify_certificate
             else:


### PR DESCRIPTION
reason: verify_certificate was already optional but always present. Now
the default install doesn't provide verify_certificate for wazo-auth