### PR TITLE
Pull request for WAZO-1747-confd-http

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,42 +39,50 @@ amid:
   host: <your_engine_ip_or_dns>
   port: 443
   prefix: /api/amid
+  https: true
   verify_certificate: false
 auth:
   host: <your_engine_ip_or_dns>
   port: 443
   timeout: 30
   prefix: /api/auth
+  https: true
   verify_certificate: false
 call-logd:
   host: <your_engine_ip_or_dns>
   port: 443
   prefix: /api/call-logd
+  https: true
   verify_certificate: false
 confd:
   host: <your_engine_ip_or_dns>
   port: 443
   prefix: /api/confd
+  https: true
   verify_certificate: false
 dird:
   host: <your_engine_ip_or_dns>
   port: 443
   prefix: /api/dird
+  https: true
   verify_certificate: false
 plugind:
   host: <your_engine_ip_or_dns>
   port: 443
   prefix: /api/plugind
+  https: true
   verify_certificate: false
 provd:
   host: <your_engine_ip_or_dns>
   port: 443
   prefix: /api/provd
+  https: true
   verify_certificate: false
 webhookd:
   host: <your_engine_ip_or_dns>
   port: 443
   prefix: /api/webhookd
+  https: true
   verify_certificate: false
 websocketd:
   host: <your_engine_ip_or_dns>

--- a/etc/wazo-ui/config.yml
+++ b/etc/wazo-ui/config.yml
@@ -41,7 +41,8 @@
 # confd:
 #   host: localhost
 #   port: 9486
-#   verify_certificate: /usr/share/xivo-certs/server.crt
+#   prefix: None
+#   https: false
 # 
 # dird:
 #   host: localhost

--- a/wazo_ui/config.py
+++ b/wazo_ui/config.py
@@ -42,7 +42,8 @@ _DEFAULT_CONFIG = {
     'confd': {
         'host': 'localhost',
         'port': 9486,
-        'verify_certificate': '/usr/share/xivo-certs/server.crt',
+        'prefix': None,
+        'https': False,
     },
     'dird': {
         'host': 'localhost',


### PR DESCRIPTION
use confd without ssl by default
README: add https section