### PR TITLE
WAZO-1807: fix prefix dird sources

### DIFF
--- a/wazo_ui/plugins/dird_source/form.py
+++ b/wazo_ui/plugins/dird_source/form.py
@@ -129,6 +129,7 @@ class WazoAuthForm(BaseForm):
 class WazoConfdForm(BaseForm):
     host = StringField(l_('Host'))
     port = StringField(l_('Port'))
+    prefix_ = StringField(l_('Prefix'))
     verify_certificate = BooleanField(l_('Verify certificate'), default=False)
     certificate_path = StringField(l_('Certificate path'))
     timeout = FloatField(l_('Timeout'))

--- a/wazo_ui/plugins/dird_source/static/wazo_engine/js/dird_source.js
+++ b/wazo_ui/plugins/dird_source/static/wazo_engine/js/dird_source.js
@@ -28,7 +28,7 @@ $(document).ready(function() {
     function disableCertificateField() {
         if(https.is(':checked')){
             $('input.auth_verify_certificate').removeAttr('disabled');
-            $('input.auth_certificate_path').removeAttr('disabled');
+            disablePathField();
         } else {
             $('input.auth_verify_certificate').attr('disabled', 'disabled');
             $('input.auth_certificate_path').attr('disabled', 'disabled');
@@ -37,21 +37,35 @@ $(document).ready(function() {
 
     verify_certificate.click(disablePathField);
     https.click(disableCertificateField);
+
     disableCertificateField();
     disablePathField();
 });
 
 $(document).ready(function() {
-    var checkbox = $('input[type="checkbox"].confd_verify_certificate');
+    var verify_certificate = $('input[type="checkbox"].confd_verify_certificate');
+    var https = $('input[type="checkbox"].confd_https');
 
-    function disableField() {
-        if(checkbox.is(':checked')){
+    function disablePathField() {
+        if(verify_certificate.is(':checked')){
             $('input.confd_certificate_path').removeAttr('disabled');
         } else {
             $('input.confd_certificate_path').attr('disabled', 'disabled');
         }
     }
 
-    checkbox.click(disableField);
-    disableField();
+    function disableCertificateField() {
+        if(https.is(':checked')){
+            $('input.confd_verify_certificate').removeAttr('disabled');
+            disablePathField();
+        } else {
+            $('input.confd_verify_certificate').attr('disabled', 'disabled');
+            $('input.confd_certificate_path').attr('disabled', 'disabled');
+        }
+    }
+
+    verify_certificate.click(disablePathField);
+    https.click(disableCertificateField);
+    disableCertificateField();
+    disablePathField();
 });

--- a/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_conference.html
+++ b/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_conference.html
@@ -51,9 +51,10 @@
               <h4>Confd</h4>
               {{ render_field(form.conference_config.confd.host) }}
               {{ render_field(form.conference_config.confd.port) }}
+              {{ render_field(form.conference_config.confd.prefix_) }}
+              {{ render_field(form.conference_config.confd.https, class_="confd_https") }}
               {{ render_field(form.conference_config.confd.verify_certificate, class_="confd_verify_certificate") }}
               {{ render_field(form.conference_config.confd.certificate_path, class_="confd_certificate_path") }}
-              {{ render_field(form.conference_config.confd.https) }}
               {{ render_field(form.conference_config.confd.timeout) }}
               {{ render_field(form.conference_config.confd.version) }}
             {% endcall %}

--- a/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_wazo.html
+++ b/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_wazo.html
@@ -51,9 +51,10 @@
               <h4>Confd</h4>
               {{ render_field(form.wazo_config.confd.host) }}
               {{ render_field(form.wazo_config.confd.port) }}
+              {{ render_field(form.wazo_config.confd.prefix_) }}
+              {{ render_field(form.wazo_config.confd.https, class_="confd_https") }}
               {{ render_field(form.wazo_config.confd.verify_certificate, class_="confd_verify_certificate") }}
               {{ render_field(form.wazo_config.confd.certificate_path, class_="confd_certificate_path") }}
-              {{ render_field(form.wazo_config.confd.https) }}
               {{ render_field(form.wazo_config.confd.timeout) }}
               {{ render_field(form.wazo_config.confd.version) }}
             {% endcall %}

--- a/wazo_ui/plugins/dird_source/view.py
+++ b/wazo_ui/plugins/dird_source/view.py
@@ -261,6 +261,9 @@ class DirdSourceView(BaseIPBXHelperView):
         if 'prefix' in resource[config_name].get('auth', {}):
             resource[config_name]['auth']['prefix_'] = resource[config_name]['auth'].pop('prefix')
 
+        if 'prefix' in resource[config_name].get('confd', {}):
+            resource[config_name]['confd']['prefix_'] = resource[config_name]['confd'].pop('prefix')
+
         # Handle `verify_certificate` for office 365 or google that can be True, False or the value of certificate_path
         if backend in ('office365', 'google', 'conference', 'wazo'):
             verify_certificate = resource[config_name]['auth'].get('verify_certificate')


### PR DESCRIPTION
The prefix field was not handled for confd configuration in the wazo and conference dird sources.