### PR TITLE
Pull request for WAZO-1814-plugind-without-ssl

### DIFF
--- a/etc/wazo-ui/config.yml
+++ b/etc/wazo-ui/config.yml
@@ -64,7 +64,8 @@
 # webhookd:
 #   host: localhost
 #   port: 9300
-#   verify_certificate: /usr/share/xivo-certs/server.crt
+#   prefix: None
+#   https: false
 #
 # websocketd:
 #   host: null  # populated with browser url

--- a/etc/wazo-ui/config.yml
+++ b/etc/wazo-ui/config.yml
@@ -54,7 +54,8 @@
 # plugind:
 #   host: localhost
 #   port: 9503
-#   verify_certificate: /usr/share/xivo-certs/server.crt
+#   prefix: None
+#   https: false
 # 
 # provd:
 #   host: localhost

--- a/wazo_ui/config.py
+++ b/wazo_ui/config.py
@@ -54,7 +54,8 @@ _DEFAULT_CONFIG = {
     'plugind': {
         'host': 'localhost',
         'port': 9503,
-        'verify_certificate': '/usr/share/xivo-certs/server.crt',
+        'prefix': None,
+        'https': False,
     },
     'provd': {
         'host': 'localhost',

--- a/wazo_ui/config.py
+++ b/wazo_ui/config.py
@@ -64,7 +64,8 @@ _DEFAULT_CONFIG = {
     'webhookd': {
         'host': 'localhost',
         'port': 9300,
-        'verify_certificate': '/usr/share/xivo-certs/server.crt',
+        'prefix': None,
+        'https': False,
     },
     # Information for websocketd are used by the client browser
     'websocketd': {


### PR DESCRIPTION
use plugind without ssl by default
use webhookd without ssl by default