### PR TITLE
Pull request for WAZO-1820-provd-without-ssl

### DIFF
--- a/etc/wazo-ui/config.yml
+++ b/etc/wazo-ui/config.yml
@@ -60,7 +60,8 @@
 # provd:
 #   host: localhost
 #   port: 8666
-#   verify_certificate: /usr/share/xivo-certs/server.crt
+#   prefix: None
+#   https: false
 # 
 # webhookd:
 #   host: localhost

--- a/wazo_ui/config.py
+++ b/wazo_ui/config.py
@@ -73,7 +73,7 @@ _DEFAULT_CONFIG = {
     'websocketd': {
         'host': None,
         'port': 443,
-        'prefix_url': '/api/websocketd',
+        'prefix': '/api/websocketd',
         'verify_certificate': False,
     },
     'enabled_plugins': {

--- a/wazo_ui/config.py
+++ b/wazo_ui/config.py
@@ -60,7 +60,8 @@ _DEFAULT_CONFIG = {
     'provd': {
         'host': 'localhost',
         'port': 8666,
-        'verify_certificate': '/usr/share/xivo-certs/server.crt',
+        'prefix': None,
+        'https': False,
     },
     'webhookd': {
         'host': 'localhost',

--- a/wazo_ui/plugins/plugin/static/wazo_engine/js/plugin.js
+++ b/wazo_ui/plugins/plugin/static/wazo_engine/js/plugin.js
@@ -7,7 +7,7 @@ $(document).ready(function() {
     search_plugins();
 });
 
-function connect(host, port, prefix_url, token) {
+function connect(host, port, prefix, token) {
     if (socket != null) {
         console.log("socket already connected");
         return;
@@ -17,7 +17,7 @@ function connect(host, port, prefix_url, token) {
         host = window.location.host;
     }
 
-    var ws_url = "wss://" + host + ":" + port + prefix_url + "/?token=" + token;
+    var ws_url = "wss://" + host + ":" + port + prefix + "/?token=" + token;
     socket = new WebSocket(ws_url);
     socket.onclose = function(event) {
         socket = null;

--- a/wazo_ui/plugins/plugin/templates/wazo_engine/plugin/list.html
+++ b/wazo_ui/plugins/plugin/templates/wazo_engine/plugin/list.html
@@ -80,7 +80,7 @@
     connect(
       "{{ config.websocketd.host or '' }}",
       "{{ config.websocketd.port }}",
-      "{{ config.websocketd.prefix_url }}",
+      "{{ config.websocketd.prefix }}",
       "{{ current_user.token }}"
     );
   </script>


### PR DESCRIPTION
use same prefix name for websocketd
use provd without ssl by default