### PR TITLE
directory: wazo: add default field for reverse lookup

### DIFF
--- a/wazo_ui/plugins/dird_source/view.py
+++ b/wazo_ui/plugins/dird_source/view.py
@@ -132,6 +132,7 @@ class DirdSourceView(BaseIPBXHelperView):
                 ],
                 'first_matched_columns': [
                     {'value': 'mobile_phone_number'},
+                    {'value': 'exten'},
                 ],
                 'format_columns': [
                     {'key': 'name', 'value': '{firstname} {lastname}'},


### PR DESCRIPTION
Why:

* Be consistent with wazo-dird defaults