### PR TITLE
remove usage of PID file and use systemd options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ COPY ./etc/wazo-ui /etc/wazo-ui
 RUN true \
     && adduser --quiet --system --group --home /var/lib/wazo-ui wazo-ui \
     && mkdir -p /etc/wazo-ui/conf.d \
-    && install -d -o wazo-ui -g wazo-ui /run/wazo-ui/ \
     && install -o wazo-ui -g wazo-ui /dev/null /var/log/wazo-ui.log
 
 

--- a/debian/wazo-ui.service
+++ b/debian/wazo-ui.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=wazo-ui
 After=network.target
-Before=monit.service
+StartLimitBurst=15
+StartLimitIntervalSec=150
 
 [Service]
-ExecStartPre=/usr/bin/install -d -o wazo-ui -g wazo-ui /run/wazo-ui
 ExecStart=/usr/bin/wazo-ui
-PIDFile=/run/wazo-ui/wazo-ui.pid
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/wazo-ui/config.yml
+++ b/etc/wazo-ui/config.yml
@@ -12,9 +12,6 @@
 # # Log file.
 # log_filename: /var/log/wazo-ui.log
 # 
-# # PID file.
-# pid_filename: /run/wazo-ui/wazo-ui.pid
-# 
 # http:
 #   listen: 127.0.0.1
 #   port: 9296

--- a/wazo_ui/bin/daemon.py
+++ b/wazo_ui/bin/daemon.py
@@ -4,12 +4,9 @@
 import sys
 
 from xivo import xivo_logging
-from xivo.daemonize import pidfile_context
 from xivo.user_rights import change_user
 from wazo_ui.config import load as load_config
 from wazo_ui.controller import Controller
-
-FOREGROUND = True  # Always in foreground systemd takes care of daemonizing
 
 
 def main():
@@ -18,12 +15,11 @@ def main():
     if config.get('user'):
         change_user(config['user'])
 
-    xivo_logging.setup_logging(config['log_filename'],
-                               FOREGROUND,
-                               config['debug'],
-                               config['log_level'])
+    xivo_logging.setup_logging(
+        config['log_filename'],
+        debug=config['debug'],
+        log_level=config['log_level'],
+    )
 
     controller = Controller(config)
-
-    with pidfile_context(config['pid_filename'], FOREGROUND):
-        controller.run()
+    controller.run()

--- a/wazo_ui/config.py
+++ b/wazo_ui/config.py
@@ -13,7 +13,6 @@ _DEFAULT_CONFIG = {
     'debug': False,
     'log_level': 'info',
     'log_filename': '/var/log/wazo-ui.log',
-    'pid_filename': '/run/wazo-ui/wazo-ui.pid',
     'session_lifetime': 60 * 60 * 8,
     'http': {
         'listen': '127.0.0.1',


### PR DESCRIPTION
reason: systemd restart remove monit usage based on pid file