### PR TITLE
use the backend name on url to get the information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .coverage
 .eggs
 .tox
+*.swp
 coverage.xml
 pycodestyle.txt
 pylint.txt

--- a/wazo_ui/plugins/dird_source/service.py
+++ b/wazo_ui/plugins/dird_source/service.py
@@ -47,9 +47,8 @@ class DirdSourceService:
 
         return getattr(self._dird, endpoints[backend]).edit(source_data['uuid'], source_data[backend + '_config'])
 
-    def delete(self, source_uuid):
-        source = self.get(source_uuid)
-        backend = source['backend']
+    def delete(self, backend, source_uuid):
+        source = self.get(backend, source_uuid)
 
         if backend not in endpoints.keys():
             return self._dird.backends.delete_source(backend, source_uuid)

--- a/wazo_ui/plugins/dird_source/service.py
+++ b/wazo_ui/plugins/dird_source/service.py
@@ -48,8 +48,6 @@ class DirdSourceService:
         return getattr(self._dird, endpoints[backend]).edit(source_data['uuid'], source_data[backend + '_config'])
 
     def delete(self, backend, source_uuid):
-        source = self.get(backend, source_uuid)
-
         if backend not in endpoints.keys():
             return self._dird.backends.delete_source(backend, source_uuid)
 

--- a/wazo_ui/plugins/dird_source/service.py
+++ b/wazo_ui/plugins/dird_source/service.py
@@ -20,17 +20,13 @@ class DirdSourceService:
     def list(self):
         return self._dird.sources.list()
 
-    def get(self, source_uuid):
-        results = [source for source in self.list()['items'] if source['uuid'] == source_uuid]
-        source = results[0] if len(results) else None
-        backend = source['backend']
-
+    def get(self, backend, source_uuid):
         if backend not in endpoints.keys():
             result = self._dird.backends.get_source(backend, source_uuid)
         else:
             result = getattr(self._dird, endpoints[backend]).get(source_uuid)
 
-        result.update(source)
+        result['backend'] = backend
         return result
 
     def create(self, source_data):

--- a/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_conference.html
+++ b/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_conference.html
@@ -7,9 +7,9 @@
   {% set submit_value = _('Add') %}
   {% set breadcrumb = { 'name': _('Add Conference source'), 'icon': 'address-book' } %}
 {% else %}
-  {% set url_action = url_for('.DirdSourceView:put', id=resource.uuid) %}
+  {% set url_action = url_for('.DirdSourceView:put', backend=backend, id=resource.uuid) %}
   {% set submit_value = _('Edit') %}
-  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', id=resource.uuid), 'icon': 'address-book' } %}
+  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', backend=backend, id=resource.uuid), 'icon': 'address-book' } %}
 {% endif %}
 
 {% block content_header %}

--- a/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_csv.html
+++ b/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_csv.html
@@ -7,9 +7,9 @@
   {% set submit_value = _('Add') %}
   {% set breadcrumb = { 'name': _('Add CSV source'), 'icon': 'address-book' } %}
 {% else %}
-  {% set url_action = url_for('.DirdSourceView:put', id=resource.uuid) %}
+  {% set url_action = url_for('.DirdSourceView:put', backend=backend, id=resource.uuid) %}
   {% set submit_value = _('Edit') %}
-  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', id=resource.uuid), 'icon': 'address-book' } %}
+  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', backend=backend, id=resource.uuid), 'icon': 'address-book' } %}
 {% endif %}
 
 {% block content_header %}

--- a/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_csv_ws.html
+++ b/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_csv_ws.html
@@ -7,9 +7,9 @@
   {% set submit_value = _('Add') %}
   {% set breadcrumb = { 'name': _('Add CSV WS source'), 'icon': 'address-book' } %}
 {% else %}
-  {% set url_action = url_for('.DirdSourceView:put', id=resource.uuid) %}
+  {% set url_action = url_for('.DirdSourceView:put', backend=backend, id=resource.uuid) %}
   {% set submit_value = _('Edit') %}
-  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', id=resource.uuid), 'icon': 'address-book' } %}
+  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', backend=backend, id=resource.uuid), 'icon': 'address-book' } %}
 {% endif %}
 
 {% block content_header %}

--- a/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_google.html
+++ b/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_google.html
@@ -7,9 +7,9 @@
   {% set submit_value = _('Add') %}
   {% set breadcrumb = { 'name': _('Add Google source'), 'icon': 'address-book' } %}
 {% else %}
-  {% set url_action = url_for('.DirdSourceView:put', id=resource.uuid) %}
+  {% set url_action = url_for('.DirdSourceView:put', backend=backend, id=resource.uuid) %}
   {% set submit_value = _('Edit') %}
-  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', id=resource.uuid), 'icon': 'address-book' } %}
+  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', backend=backend, id=resource.uuid), 'icon': 'address-book' } %}
 {% endif %}
 
 {% block content_header %}

--- a/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_ldap.html
+++ b/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_ldap.html
@@ -7,9 +7,9 @@
   {% set submit_value = _('Add') %}
   {% set breadcrumb = { 'name': _('Add LDAP source'), 'icon': 'address-book' } %}
 {% else %}
-  {% set url_action = url_for('.DirdSourceView:put', id=resource.uuid) %}
+  {% set url_action = url_for('.DirdSourceView:put', backend=backend, id=resource.uuid) %}
   {% set submit_value = _('Edit') %}
-  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', id=resource.uuid), 'icon': 'address-book' } %}
+  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', backend=backend, id=resource.uuid), 'icon': 'address-book' } %}
 {% endif %}
 
 {% block content_header %}

--- a/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_office365.html
+++ b/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_office365.html
@@ -7,9 +7,9 @@
   {% set submit_value = _('Add') %}
   {% set breadcrumb = { 'name': _('Add Office 365 source'), 'icon': 'address-book' } %}
 {% else %}
-  {% set url_action = url_for('.DirdSourceView:put', id=resource.uuid) %}
+  {% set url_action = url_for('.DirdSourceView:put', backend=backend, id=resource.uuid) %}
   {% set submit_value = _('Edit') %}
-  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', id=resource.uuid), 'icon': 'address-book' } %}
+  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', backend=backend, id=resource.uuid), 'icon': 'address-book' } %}
 {% endif %}
 
 {% block content_header %}

--- a/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_personal.html
+++ b/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_personal.html
@@ -7,9 +7,9 @@
   {% set submit_value = _('Add') %}
   {% set breadcrumb = { 'name': _('Add a Personal source'), 'icon': 'address-book' } %}
 {% else %}
-  {% set url_action = url_for('.DirdSourceView:put', id=resource.uuid) %}
+  {% set url_action = url_for('.DirdSourceView:put', backend=backend, id=resource.uuid) %}
   {% set submit_value = _('Edit') %}
-  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', id=resource.uuid), 'icon': 'address-book' } %}
+  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', backend=backend, id=resource.uuid), 'icon': 'address-book' } %}
 {% endif %}
 
 {% block content_header %}

--- a/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_phonebook.html
+++ b/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_phonebook.html
@@ -7,9 +7,9 @@
   {% set submit_value = _('Add') %}
   {% set breadcrumb = { 'name': _('Add Phonebook source'), 'icon': 'address-book' } %}
 {% else %}
-  {% set url_action = url_for('.DirdSourceView:put', id=resource.uuid) %}
+  {% set url_action = url_for('.DirdSourceView:put', backend=backend, id=resource.uuid) %}
   {% set submit_value = _('Edit') %}
-  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', id=resource.uuid), 'icon': 'address-book' } %}
+  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', backend=backend, id=resource.uuid), 'icon': 'address-book' } %}
 {% endif %}
 
 {% block content_header %}

--- a/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_wazo.html
+++ b/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/form/form_wazo.html
@@ -7,9 +7,9 @@
   {% set submit_value = _('Add') %}
   {% set breadcrumb = { 'name': _('Add Wazo source'), 'icon': 'address-book' } %}
 {% else %}
-  {% set url_action = url_for('.DirdSourceView:put', id=resource.uuid) %}
+  {% set url_action = url_for('.DirdSourceView:put', backend=backend, id=resource.uuid) %}
   {% set submit_value = _('Edit') %}
-  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', id=resource.uuid), 'icon': 'address-book' } %}
+  {% set breadcrumb = { 'name': resource.name, 'link': url_for('.DirdSourceView:get', backend=backend, id=resource.uuid), 'icon': 'address-book' } %}
 {% endif %}
 
 {% block content_header %}

--- a/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/list.html
+++ b/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/list.html
@@ -30,7 +30,3 @@
     {% endcall %}
   </section>
 {% endblock %}
-
-{% block additional_js %}
-  <script src="{{ url_for('.static', filename='js/dird_source.js') }}"></script>
-{% endblock %}

--- a/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/list.html
+++ b/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/list.html
@@ -10,7 +10,7 @@
   <section class="content">
     {% call build_list_containers(_('Directory'), 'address-book') %}
       {% call build_list_table() %}
-        {% call build_list_table_headers(get=url_for('.DirdSourceView:get', backend='', id=''), delete=url_for('.DirdSourceView:delete', id='')) %}
+        {% call build_list_table_headers(get=url_for('.DirdSourceView:get', backend='', id=''), delete=url_for('.DirdSourceView:delete', backend='', id='')) %}
           <th>{{ _('Name') }}</th>
           <th>{{ _('Backend') }}</th>
         {% endcall %}

--- a/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/list.html
+++ b/wazo_ui/plugins/dird_source/templates/wazo_engine/dird_source/list.html
@@ -10,7 +10,7 @@
   <section class="content">
     {% call build_list_containers(_('Directory'), 'address-book') %}
       {% call build_list_table() %}
-        {% call build_list_table_headers(get=url_for('.DirdSourceView:get', id=''), delete=url_for('.DirdSourceView:delete', id='')) %}
+        {% call build_list_table_headers(get=url_for('.DirdSourceView:get', backend='', id=''), delete=url_for('.DirdSourceView:delete', id='')) %}
           <th>{{ _('Name') }}</th>
           <th>{{ _('Backend') }}</th>
         {% endcall %}
@@ -29,4 +29,8 @@
       {% endfor %}
     {% endcall %}
   </section>
+{% endblock %}
+
+{% block additional_js %}
+  <script src="{{ url_for('.static', filename='js/dird_source.js') }}"></script>
 {% endblock %}

--- a/wazo_ui/plugins/dird_source/view.py
+++ b/wazo_ui/plugins/dird_source/view.py
@@ -190,6 +190,16 @@ class DirdSourceView(BaseIPBXHelperView):
         flash('Resource has been created', 'success')
         return self._redirect_for('index')
 
+    @route('/delete/<backend>/<id>', methods=['GET'])
+    def delete(self, backend, id):
+        try:
+            self.service.delete(backend, id)
+            flash(l_('%(resource)s: Resource %(id)s has been deleted', resource=self.resource, id=id), 'success')
+        except HTTPError as error:
+            self._flash_http_error(error)
+
+        return self._redirect_referrer_or('index')
+
     def _map_form_to_resources(self, form, form_id=None):
         resource = super()._map_form_to_resources(form, form_id)
         backend = resource['backend']

--- a/wazo_ui/plugins/dird_source/view.py
+++ b/wazo_ui/plugins/dird_source/view.py
@@ -189,6 +189,24 @@ class DirdSourceView(BaseIPBXHelperView):
         flash('Resource has been created', 'success')
         return self._redirect_for('index')
 
+    @route('/put/<backend>/<id>', methods=['POST'])
+    def put(self, backend, id):
+        form = self.form()
+        if not form.csrf_token.validate(form):
+            self._flash_basic_form_errors(form)
+            return self._get(backend, id, form)
+
+        resources = self._map_form_to_resources_put(form, id)
+        try:
+            self.service.update(resources)
+        except HTTPError as error:
+            form = self._fill_form_error(form, error)
+            self._flash_http_error(error)
+            return self._get(backend, id, form)
+
+        flash(l_('%(resource)s: Resource has been updated', resource=self.resource), 'success')
+        return self._redirect_referrer_or('index')
+
     @route('/delete/<backend>/<id>', methods=['GET'])
     def delete(self, backend, id):
         try:

--- a/wazo_ui/plugins/dird_source/view.py
+++ b/wazo_ui/plugins/dird_source/view.py
@@ -26,11 +26,10 @@ class DirdSourceView(BaseIPBXHelperView):
 
     def _index(self, form=None):
         try:
-            resources_list = self.service.list()
             resource_list = {"items": []}
-            for r in resources_list['items']:
-                r['get_url'] = "{}/".format(r['backend'])
-                resource_list['items'].append(r)
+            for source in self.service.list()['items']:
+                source['get_url'] = "{}/".format(source['backend'])
+                resource_list['items'].append(source)
             backend_list = self.service.list_backends()
         except HTTPError as error:
             self._flash_http_error(error)

--- a/wazo_ui/plugins/dird_source/view.py
+++ b/wazo_ui/plugins/dird_source/view.py
@@ -26,7 +26,11 @@ class DirdSourceView(BaseIPBXHelperView):
 
     def _index(self, form=None):
         try:
-            resource_list = self.service.list()
+            resources_list = self.service.list()
+            resource_list = {"items": []}
+            for r in resources_list['items']:
+                r['get_url'] = "{}/".format(r['backend'])
+                resource_list['items'].append(r)
             backend_list = self.service.list_backends()
         except HTTPError as error:
             self._flash_http_error(error)
@@ -148,9 +152,13 @@ class DirdSourceView(BaseIPBXHelperView):
                                current_breadcrumbs=self._get_current_breadcrumbs(),
                                form=form)
 
-    def _get(self, id, form=None):
+    @route('/get/<backend>/<id>')
+    def get(self, backend, id):
+        return self._get(backend, id)
+
+    def _get(self, backend, id, form=None):
         try:
-            resource = self.service.get(id)
+            resource = self.service.get(backend, id)
         except HTTPError as error:
             self._flash_http_error(error)
             return self._redirect_for('index')
@@ -158,7 +166,7 @@ class DirdSourceView(BaseIPBXHelperView):
         form = form or self._map_resources_to_form(resource)
         form = self._populate_form(form)
 
-        return render_template(self._get_template(backend=resource['backend']),
+        return render_template(self._get_template(backend=backend),
                                form=form,
                                resource=resource,
                                current_breadcrumbs=self._get_current_breadcrumbs(),

--- a/wazo_ui/static/js/wazo-ui.js
+++ b/wazo_ui/static/js/wazo-ui.js
@@ -528,10 +528,12 @@ function addIdToURL(url, id) {
 }
 
 function get_row_infos(row) {
-  var data_uuid, data_id, data_tenant_uuid, data_non_unique_id;
+  var data_uuid, data_id, data_tenant_uuid, data_non_unique_id, data_get_url;
 
   data_uuid = row.uuid ? row.uuid : row.attr('data-uuid');
   data_id = row.id ? row.id : row.attr('data-id');
+  data_get_url = row.get_url ? row.get_url : row.attr('data-get_url');
+
   if (row.tenant_uuid) {
     data_tenant_uuid = row.tenant_uuid;
   } else {
@@ -539,6 +541,10 @@ function get_row_infos(row) {
   }
   data_non_unique_id = row.attr('data-non-unique-id') === 'True';
   var data_infos = get_data_infos(row.parent().parent());
+
+  if (data_get_url) {
+    data_infos.get_url = data_infos.get_url.slice(0, -1) + data_get_url;
+  }
 
   if (data_tenant_uuid && data_non_unique_id) {
     if (data_infos.get_url) {

--- a/wazo_ui/static/js/wazo-ui.js
+++ b/wazo_ui/static/js/wazo-ui.js
@@ -544,6 +544,7 @@ function get_row_infos(row) {
 
   if (data_get_url) {
     data_infos.get_url = data_infos.get_url.slice(0, -1) + data_get_url;
+    data_infos.delete_url = data_infos.delete_url.slice(0, -1) + data_get_url;
   }
 
   if (data_tenant_uuid && data_non_unique_id) {

--- a/wazo_ui/templates/macro.html
+++ b/wazo_ui/templates/macro.html
@@ -326,7 +326,7 @@
   {% call build_table_body() %}
     {% for item in items %}
       {% set editable = false if item.editable == False else true %}
-      <tr{{ ' data-id=' ~ item.id if item.id }}{{ ' data-uuid=' ~ item.uuid if item.uuid }}{{ ' data-tenant-uuid=' ~ item.tenant_uuid if item.tenant_uuid }}{{ ' data-non-unique-id=' ~ non_unique_id if non_unique_id }} data-editable="{{ editable }}">
+      <tr{{ ' data-id=' ~ item.id if item.id }}{{ ' data-uuid=' ~ item.uuid if item.uuid }}{{ ' data-tenant-uuid=' ~ item.tenant_uuid if item.tenant_uuid }}{{ ' data-non-unique-id=' ~ non_unique_id if non_unique_id }}{{ ' data-get_url=' ~ item.get_url if item.get_url }} data-editable="{{ editable }}">
         {{ caller_(item) }}
       </tr>
     {% endfor %}


### PR DESCRIPTION
Because we want to have plugins for wazo-ui and dird_source, to intercept the url we need to know the name of the backend instead only the source uuid. We change the internal URL to /backend/source_uuid on the GET instead only /source_uuid. I added a new parameter get_url to override the default url on the double click.