### PR TITLE
Pull request for WAZO-1632-fix-pjsip-dropdown

### DIFF
--- a/wazo_ui/plugins/general_settings/view.py
+++ b/wazo_ui/plugins/general_settings/view.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 import logging
@@ -290,5 +290,6 @@ class PJSIPDocListingView(LoginRequiredView):
     def list_json_by_section(self, section):
         params = extract_select2_params(request.args)
         doc = self.service.get().get(section, {}).keys()
-        with_id = [{'id': key, 'text': key} for key in doc]
-        return jsonify(build_select2_response(with_id, len(doc), params))
+        term = params.get('search') or ''
+        with_id = [{'id': key, 'text': key} for key in doc if term in key]
+        return jsonify(build_select2_response(with_id, len(with_id), params))

--- a/wazo_ui/plugins/general_settings/view.py
+++ b/wazo_ui/plugins/general_settings/view.py
@@ -292,4 +292,5 @@ class PJSIPDocListingView(LoginRequiredView):
         doc = self.service.get().get(section, {}).keys()
         term = params.get('search') or ''
         with_id = [{'id': key, 'text': key} for key in doc if term in key]
+        params['limit'] = len(with_id)  # avoid pagination
         return jsonify(build_select2_response(with_id, len(with_id), params))


### PR DESCRIPTION
## allow to search into pjsip options


## avoid paginate pjsip options

reason: by default we query dropdown with a limit/offset, but with
pjsip, we don't care of it. So we force to remove pagination