### PR TITLE
freeze sqlalchemy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ flask==1.0.2
 itsdangerous==0.24
 pyyaml==3.13  # from xivo-lib-python
 requests==2.21.0
+sqlalchemy==1.2.18  # frozen to avoid flask-sqlalchemy conflict
 stevedore==1.29.0
 werkzeug==0.14.1
 wtforms==2.2.1


### PR DESCRIPTION
reason: flask-sqlalchgemy depends on the latest sqlalchemy version, but
the new one (1.4.0) breaks compatibility

In production, buster contains only sqlalchemy 1.2.18