### PR TITLE
test: use explicit ipv4 addr to connect docker

### DIFF
--- a/integration_tests/suite/helpers/asset_launching_test_case.py
+++ b/integration_tests/suite/helpers/asset_launching_test_case.py
@@ -33,6 +33,6 @@ class AdminUIAssetLaunchingTestCase(AssetLaunchingTestCase):
         Page.CONFIG['base_url'] = 'http://ui:9296'
 
         browser_port = cls.service_port(4444, 'browser')
-        remote_url = 'http://localhost:{port}/wd/hub'.format(port=browser_port)
+        remote_url = 'http://127.0.0.1:{port}/wd/hub'.format(port=browser_port)
         browser = RemoteBrowser(remote_url, username, password)
         return browser


### PR DESCRIPTION
reason: service_port() returns only port bound to ipv4. Some host can
resolve localhost to ipv6 address and docker doesn't necessarily bind
the same port number on ipv4 and ipv6