### PR TITLE
Review external auth

### DIFF
--- a/wazo_ui/plugins/external_auth/service.py
+++ b/wazo_ui/plugins/external_auth/service.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import session
@@ -24,8 +24,8 @@ class ExternalAuthService:
 
         return {'items': items}
 
-    def get(self, type):
-        service = self._auth.external.get_config(type)
+    def get(self, backend):
+        service = self._auth.external.get_config(backend)
         return service
 
     def create(self, auth_data, form):
@@ -41,8 +41,9 @@ class ExternalAuthService:
     def delete(self, auth_type):
         return self._auth.external.delete_config(auth_type)
 
-    def list_types(self):
-        return ['microsoft', 'mobile', 'google']
+    def list_backend(self):
+        service_list = self._auth.external.list_(session['working_instance_tenant_uuid'])
+        return [service['type'] for service in service_list['items']]
 
     def _parse_payload(self, auth_data):
         auth_type = auth_data['type']

--- a/wazo_ui/plugins/external_auth/service.py
+++ b/wazo_ui/plugins/external_auth/service.py
@@ -1,7 +1,7 @@
 # Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from flask import session
+from flask_login import current_user
 from requests.exceptions import HTTPError
 
 
@@ -11,7 +11,7 @@ class ExternalAuthService:
         self._auth = auth_client
 
     def list(self):
-        service_list = self._auth.external.list_(session['working_instance_tenant_uuid'])
+        service_list = self._auth.external.list_(current_user.uuid)
         items = []
 
         for service in service_list['items']:
@@ -42,7 +42,7 @@ class ExternalAuthService:
         return self._auth.external.delete_config(auth_type)
 
     def list_backend(self):
-        service_list = self._auth.external.list_(session['working_instance_tenant_uuid'])
+        service_list = self._auth.external.list_(current_user.uuid)
         return [service['type'] for service in service_list['items']]
 
     def _parse_payload(self, auth_data):

--- a/wazo_ui/plugins/external_auth/templates/wazo_engine/external_auth/list.html
+++ b/wazo_ui/plugins/external_auth/templates/wazo_engine/external_auth/list.html
@@ -2,13 +2,13 @@
 
 {% block content_header %}
   {{ build_breadcrumbs(current_breadcrumbs + [
-    { 'name': _('External Auth'), 'link': url_for('.ExternalAuthView:index'), 'icon': 'address-book' }
+    { 'name': _('External Auth'), 'link': url_for('.ExternalAuthView:index'), 'icon': 'external-link' }
   ]) }}
 {% endblock %}
 
 {% block content %}
   <section class="content">
-    {% call build_list_containers(_('Directory'), 'address-book') %}
+    {% call build_list_containers(_('External Auth'), 'external-link') %}
       {% call build_list_table() %}
         {% call build_list_table_headers(get=url_for('.ExternalAuthView:get', id=''), delete=url_for('.ExternalAuthView:delete', id='')) %}
           <th>{{ _('Type') }}</th>
@@ -20,7 +20,7 @@
     {% endcall %}
 
     {% if type_list | length %}
-      {% call build_hidden_add_containers(_('Add Directory Source')) %}
+      {% call build_hidden_add_containers(_('Add External Authentication')) %}
         {% for type in type_list %}
          <a class="btn btn-block btn-default" href="{{ url_for('.ExternalAuthView:new', type=type) }}">
            {{ type }}

--- a/wazo_ui/plugins/external_auth/view.py
+++ b/wazo_ui/plugins/external_auth/view.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
 from flask import request, redirect, url_for, render_template, flash
@@ -22,7 +22,7 @@ class ExternalAuthView(BaseIPBXHelperView):
     def _index(self, form=None):
         try:
             resource_list = self.service.list()
-            type_list = self.service.list_types()
+            backend_list = self.service.list_backend()
         except HTTPError as error:
             self._flash_http_error(error)
             return redirect(url_for('index.IndexView:index'))
@@ -35,7 +35,7 @@ class ExternalAuthView(BaseIPBXHelperView):
 
         configured_types = [service['type'] for service in resource_list['items']]
 
-        type_list = [service_type for service_type in type_list if service_type not in configured_types]
+        type_list = [service_type for service_type in backend_list if service_type not in configured_types]
 
         return render_template(self._get_template('list'),
                                form=form,


### PR DESCRIPTION
The external auth list has been hardcoded. If you add a plugin to add a new external auth, it's impossible to configure it. Just remove the hardcoded list and rename some stuff probably from copy/paste.