### PR TITLE
[WAZO-2614] extension: fix order of columns in template

### DIFF
--- a/wazo_ui/plugins/extension/templates/wazo_engine/extension/list.html
+++ b/wazo_ui/plugins/extension/templates/wazo_engine/extension/list.html
@@ -24,10 +24,10 @@
           <td>{{ extension.exten }}</td>
           <td>{{ extension.context }}</td>
           <td>
-            {{ extension.parking_lot.id  if extension.parking_lot else '-' }}
+            {{ extension.conference.id  if extension.conference else '-' }}
           </td>
           <td>
-            {{ extension.conference.id  if extension.conference else '-' }}
+            {{ extension.parking_lot.id  if extension.parking_lot else '-' }}
           </td>
           <td>
             {{ extension.group.id  if extension.group else '-' }}


### PR DESCRIPTION
Why: parking lot ID and conference ID was reversed