### PR TITLE
queue/group convert empty string to null

### DIFF
--- a/wazo_ui/plugins/group/view.py
+++ b/wazo_ui/plugins/group/view.py
@@ -83,7 +83,7 @@ class GroupView(BaseIPBXHelperView):
         resource['members']['users'] = [{'uuid': user_uuid} for user_uuid in form.members.user_uuids.data]
         resource['call_permissions'] = [{'id': call_permission_id} for call_permission_id in
                                         form.call_permission_ids.data]
-        resource['music_on_hold'] = form.music_on_hold.data or None
+        resource['music_on_hold'] = self._convert_empty_string_to_none(form.music_on_hold.data)
         return resource
 
     def _map_resources_to_form_errors(self, form, resources):

--- a/wazo_ui/plugins/queue/view.py
+++ b/wazo_ui/plugins/queue/view.py
@@ -93,7 +93,7 @@ class QueueView(BaseIPBXHelperView):
         resource['options'] = self._map_form_to_resource_options(form, resource)
         resource['agents'] = [{'id': agent_id} for agent_id in resource['members']['agent_ids']]
         resource['users'] = [{'id': user_id} for user_id in resource['members']['user_ids']]
-        resource['music_on_hold'] = form.music_on_hold.data or None
+        resource['music_on_hold'] = self._convert_empty_string_to_none(form.music_on_hold.data)
 
         return resource
 


### PR DESCRIPTION
why: since 21.14, we force to have an existing music_on_hold, this bug
raise an error when create queue/group