### PR TITLE
tests: remove easyprocess dependency from code

### DIFF
--- a/integration_tests/suite/helpers/pages/browser.py
+++ b/integration_tests/suite/helpers/pages/browser.py
@@ -6,12 +6,10 @@ import logging
 from selenium import webdriver
 from selenium.webdriver.remote.remote_connection import LOGGER
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
-from easyprocess import log as easyprocess_logger
 from pyvirtualdisplay import Display
 
 from .login import LoginPage
 
-easyprocess_logger.setLevel(logging.CRITICAL)
 LOGGER.setLevel(logging.CRITICAL)
 
 


### PR DESCRIPTION
why: pyvirtualdisplay >=3.0 doesn't depend anymore from easyprocess