### PR TITLE
pin itsdangerous version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ flask-sqlalchemy==2.1
 flask-wtf==0.14.2
 flask==1.0.2
 itsdangerous==0.24
+itsdangerous==0.24  # from flask
 pyyaml==3.13  # from xivo-lib-python
 requests==2.21.0
 sqlalchemy==1.2.18  # frozen to avoid flask-sqlalchemy conflict


### PR DESCRIPTION
why: if not pinned, pip install latest version (2.1.0) which is
incompatible with flask 1.0.2 from buster