### PR TITLE
pin jinja2 and marksupsafe to buster version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,8 @@ flask-wtf==0.14.2
 flask==1.0.2
 itsdangerous==0.24
 itsdangerous==0.24  # from flask
+jinja2==2.10  # from flask
+markupsafe==1.1.0 # from flask
 pyyaml==3.13  # from xivo-lib-python
 requests==2.21.0
 sqlalchemy==1.2.18  # frozen to avoid flask-sqlalchemy conflict


### PR DESCRIPTION
why: latest jinja2 version (3.1.0) is incompatible with flask 1.0.2
(from buster)

and newer markupsafe versions (> 2) are incompatible with buster jinja2