### PR TITLE
test: use mock from unittest library

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
-mock
 pyhamcrest
 pytest

--- a/wazo_ui/helpers/tests/test_classful.py
+++ b/wazo_ui/helpers/tests/test_classful.py
@@ -5,7 +5,7 @@ import unittest
 
 from flask import Flask
 from hamcrest import assert_that, empty, is_, equal_to, has_items, matches_regexp
-from mock import Mock
+from unittest.mock import Mock
 from wtforms import StringField
 
 from ..classful import BaseView, _is_positive_integer, extract_select2_params, build_select2_response

--- a/wazo_ui/helpers/tests/test_error.py
+++ b/wazo_ui/helpers/tests/test_error.py
@@ -4,7 +4,7 @@
 import unittest
 
 from hamcrest import assert_that, any_of, equal_to, empty, is_, none
-from mock import Mock
+from unittest.mock import Mock
 
 from ..error import ErrorExtractor, ErrorTranslator, ConfdErrorExtractor, ConfdErrorTranslator
 

--- a/wazo_ui/helpers/tests/test_service.py
+++ b/wazo_ui/helpers/tests/test_service.py
@@ -4,7 +4,7 @@
 import unittest
 
 from hamcrest import assert_that, equal_to
-from mock import Mock
+from unittest.mock import Mock
 
 from wazo_ui.helpers.service import BaseConfdService
 from wazo_ui.helpers.extension import BaseConfdExtensionService

--- a/wazo_ui/helpers/tests/test_view.py
+++ b/wazo_ui/helpers/tests/test_view.py
@@ -5,7 +5,7 @@ import unittest
 
 from flask import Flask
 from hamcrest import assert_that, contains, empty
-from mock import Mock
+from unittest.mock import Mock
 from wtforms import StringField
 
 from wazo_ui.helpers.form import BaseForm

--- a/wazo_ui/plugins/call_permission/tests/test_service.py
+++ b/wazo_ui/plugins/call_permission/tests/test_service.py
@@ -4,7 +4,7 @@
 from unittest import TestCase
 
 from hamcrest import assert_that, contains_inanyorder, empty
-from mock import Mock
+from unittest.mock import Mock
 
 from ..service import CallPermissionService
 

--- a/wazo_ui/plugins/user/tests/test_service.py
+++ b/wazo_ui/plugins/user/tests/test_service.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from mock import Mock, call
+from unittest.mock import Mock, call
 
 import wazo_ui.helpers.service
 import wazo_ui.plugins.user.service as service


### PR DESCRIPTION
why: pypi version is a backport if the python3 builtin package