### PR TITLE
Pull request for fix-deprecated-selenium-find-element

### DIFF
--- a/integration_tests/suite/helpers/pages/login.py
+++ b/integration_tests/suite/helpers/pages/login.py
@@ -11,7 +11,7 @@ from .page import Page
 
 class LoginPage(Page):
 
-    PATH = "/login"
+    PATH = '/login'
 
     def login(self, username, password, language='en'):
         self.go()
@@ -38,7 +38,7 @@ class LoginPage(Page):
         return self
 
     def save(self, waiting=True):
-        btn = self.driver.find_element(By.ID, "submit")
+        btn = self.driver.find_element(By.ID, 'submit')
         btn.click()
         if waiting:
             self.wait_for(By.CLASS_NAME, 'wazo-logo')

--- a/integration_tests/suite/helpers/pages/login.py
+++ b/integration_tests/suite/helpers/pages/login.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -22,10 +22,10 @@ class LoginPage(Page):
 
     def logout(self):
         try:
-            user_menu = self.driver.find_element_by_class_name('user-menu')
+            user_menu = self.driver.find_element(By.CLASS_NAME, 'user-menu')
             user_menu.click()
             self.wait_for(By.ID, 'logout')
-            btn = self.driver.find_element_by_id('logout')
+            btn = self.driver.find_element(By.ID, 'logout')
         except NoSuchElementException:
             return
         btn.click()
@@ -38,7 +38,7 @@ class LoginPage(Page):
         return self
 
     def save(self, waiting=True):
-        btn = self.driver.find_element_by_id("submit")
+        btn = self.driver.find_element(By.ID, "submit")
         btn.click()
         if waiting:
             self.wait_for(By.CLASS_NAME, 'wazo-logo')

--- a/integration_tests/suite/helpers/pages/page.py
+++ b/integration_tests/suite/helpers/pages/page.py
@@ -31,9 +31,9 @@ class Page(object):
 
     def build_url(self, *parts, **kwargs):
         path = '/'.join(parts)
-        url = "{}/{}".format(self.CONFIG['base_url'].rstrip('/'), path.lstrip('/'))
+        url = '{}/{}'.format(self.CONFIG['base_url'].rstrip('/'), path.lstrip('/'))
         if kwargs:
-            url += "?{}".format(urllib.parse.urlencode(kwargs))
+            url += '?{}'.format(urllib.parse.urlencode(kwargs))
         return url
 
     def wait(self):
@@ -109,19 +109,19 @@ class Page(object):
 
     def extract_errors(self):
         try:
-            container = self.driver.find_element(By.CLASS_NAME, "alert-error")
+            container = self.driver.find_element(By.CLASS_NAME, 'alert-error')
         except NoSuchElementException:
             return ''
 
         return container.get_attribute('innerHTML')
 
     def save(self):
-        btn = self.driver.find_element(By.ID, "submit")
+        btn = self.driver.find_element(By.ID, 'submit')
         btn.click()
         self.wait_for(By.CSS_SELECTOR, '.alert')
 
         try:
-            self.driver.find_element(By.CLASS_NAME, "alert-success")
+            self.driver.find_element(By.CLASS_NAME, 'alert-success')
         except NoSuchElementException:
             raise SubmitException(self.extract_errors())
 
@@ -242,7 +242,7 @@ class ListPage(Page, metaclass=abc.ABCMeta):
         self.wait_for_list_table()
 
     def get_row(self, text):
-        table = self.driver.find_element(By.CSS_SELECTOR, "table tbody")
+        table = self.driver.find_element(By.CSS_SELECTOR, 'table tbody')
         xpath = '//tr[td[contains(., "{}")]]'.format(text)
         headers = self._extract_headers(table)
         return ListRow(table.find_element(By.XPATH, xpath), headers=headers)

--- a/integration_tests/suite/helpers/pages/page.py
+++ b/integration_tests/suite/helpers/pages/page.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import abc
@@ -83,7 +83,7 @@ class Page(object):
 
     def get_value(self, id_, root=None):
         root = root or self.driver
-        element = root.find_element_by_id(id_)
+        element = root.find_element(By.ID, id_)
         return element.get_attribute('value')
 
     def get_int_value(self, id_, root=None):
@@ -91,7 +91,7 @@ class Page(object):
 
     def get_checked(self, id_, root=None):
         root = root or self.driver
-        element = root.find_element_by_id(id_)
+        element = root.find_element(By.ID, id_)
         checked = element.get_attribute('checked')
         if checked:
             return True
@@ -99,29 +99,29 @@ class Page(object):
 
     def get_selected_option_value(self, id_, root=None):
         root = root or self.driver
-        element = root.find_element_by_id(id_)
+        element = root.find_element(By.ID, id_)
         return Select(element).first_selected_option.get_attribute('value')
 
     def get_input_name(self, name, root=None):
         root = root or self.driver
-        element = root.find_element_by_name(name)
+        element = root.find_element(By.NAME, name)
         return InputElement(element)
 
     def extract_errors(self):
         try:
-            container = self.driver.find_element_by_class_name("alert-error")
+            container = self.driver.find_element(By.CLASS_NAME, "alert-error")
         except NoSuchElementException:
             return ''
 
         return container.get_attribute('innerHTML')
 
     def save(self):
-        btn = self.driver.find_element_by_id("submit")
+        btn = self.driver.find_element(By.ID, "submit")
         btn.click()
         self.wait_for(By.CSS_SELECTOR, '.alert')
 
         try:
-            self.driver.find_element_by_class_name("alert-success")
+            self.driver.find_element(By.CLASS_NAME, "alert-success")
         except NoSuchElementException:
             raise SubmitException(self.extract_errors())
 
@@ -144,14 +144,14 @@ class InputElement(WebElement):
         super(InputElement, self).__init__(element.parent, element.id)
 
     def get_error(self):
-        errors = self.parent.find_element_by_class_name('with-errors')
+        errors = self.parent.find_element(By.CLASS_NAME, 'with-errors')
         try:
-            return errors.find_element_by_css_selector('ul li')
+            return errors.find_element(By.CSS_SELECTOR, 'ul li')
         except NoSuchElementException:
             return errors
 
     def has_error_class(self):
-        errors = self.parent.find_element_by_class_name('has-error')
+        errors = self.parent.find_element(By.CLASS_NAME, 'has-error')
         try:
             return errors.get_attribute('class')
         except NoSuchElementException:
@@ -189,12 +189,12 @@ class ListPage(Page, metaclass=abc.ABCMeta):
         return self.form_page(self.driver)
 
     def add_form(self):
-        btn = self.driver.find_element_by_id('add-form')
+        btn = self.driver.find_element(By.ID, 'add-form')
         btn.click()
 
     def display_add_form(self):
         self.add_form()
-        return self.driver.find_element_by_css_selector('form')
+        return self.driver.find_element(By.CSS_SELECTOR, 'form')
 
     def wait_for_form(self):
         condition = ec.presence_of_element_located(self.form_selector)
@@ -207,10 +207,10 @@ class ListPage(Page, metaclass=abc.ABCMeta):
     def edit(self, name):
         xpath = self.edit_xpath.format(name=name)
 
-        line = self.driver.find_element_by_xpath(xpath)
+        line = self.driver.find_element(By.XPATH, xpath)
         line.click()
 
-        btn = self.driver.find_element_by_id('edit-selected-row')
+        btn = self.driver.find_element(By.ID, 'edit-selected-row')
         btn.click()
 
         self.wait_for_form()
@@ -226,7 +226,7 @@ class ListPage(Page, metaclass=abc.ABCMeta):
     def delete(self, name):
         xpath = self.delete_xpath.format(name=name)
 
-        button = self.driver.find_element_by_xpath(xpath)
+        button = self.driver.find_element(By.XPATH, xpath)
         button.click()
 
         condition = ec.alert_is_present()
@@ -242,14 +242,14 @@ class ListPage(Page, metaclass=abc.ABCMeta):
         self.wait_for_list_table()
 
     def get_row(self, text):
-        table = self.driver.find_element_by_css_selector("table tbody")
+        table = self.driver.find_element(By.CSS_SELECTOR, "table tbody")
         xpath = '//tr[td[contains(., "{}")]]'.format(text)
         headers = self._extract_headers(table)
-        return ListRow(table.find_element_by_xpath(xpath), headers=headers)
+        return ListRow(table.find_element(By.XPATH, xpath), headers=headers)
 
     def _extract_headers(self, table):
         xpath = '//tr/th'
-        headers = table.find_elements_by_xpath(xpath)
+        headers = table.find_elements(By.XPATH, xpath)
         return [header.text for header in headers]
 
     def find_row(self, text):
@@ -267,5 +267,5 @@ class ListRow(object):
 
     def extract(self, column):
         index = self.headers.index(column)
-        box = self.row.find_element_by_css_selector('td:nth-child({})'.format(index + 1))
+        box = self.row.find_element(By.CSS_SELECTOR, 'td:nth-child({})'.format(index + 1))
         return box.text

--- a/integration_tests/suite/helpers/pages/select2.py
+++ b/integration_tests/suite/helpers/pages/select2.py
@@ -45,7 +45,7 @@ class Select2(object):
 
     def ajax_complete(self, driver):
         try:
-            return driver.execute_script("return jQuery.active == 0")
+            return driver.execute_script('return jQuery.active == 0')
         except WebDriverException:
             return False
 
@@ -64,7 +64,7 @@ class Select2(object):
     @property
     def items(self):
         self.open()
-        WebDriverWait(self.browser, self.TIMEOUT).until(self.ajax_complete, "Timeout waiting for page to load")
+        WebDriverWait(self.browser, self.TIMEOUT).until(self.ajax_complete, 'Timeout waiting for page to load')
         return self.dropdown.find_elements(
             By.CSS_SELECTOR,
             'ul.select2-results__options li.select2-results__option',

--- a/integration_tests/suite/helpers/pages/select2.py
+++ b/integration_tests/suite/helpers/pages/select2.py
@@ -1,4 +1,4 @@
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # Based from https://gist.github.com/rafaelugolini/d2067a8c8c54026ac029
@@ -16,8 +16,10 @@ class Select2(object):
 
     def __init__(self, element, root):
         self.browser = root
-        self.element = self.browser.find_element_by_id(
-            'select2-{0}-container'.format(element.get_attribute('id')))
+        self.element = self.browser.find_element(
+            By.ID,
+            'select2-{0}-container'.format(element.get_attribute('id')),
+        )
 
     def click(self, element=None):
         if element is None:
@@ -57,11 +59,13 @@ class Select2(object):
 
     @property
     def dropdown(self):
-        return self.browser.find_element_by_css_selector('span.select2-dropdown')
+        return self.browser.find_element(By.CSS_SELECTOR, 'span.select2-dropdown')
 
     @property
     def items(self):
         self.open()
         WebDriverWait(self.browser, self.TIMEOUT).until(self.ajax_complete, "Timeout waiting for page to load")
-        return self.dropdown.find_elements_by_css_selector(
-            'ul.select2-results__options li.select2-results__option')
+        return self.dropdown.find_elements(
+            By.CSS_SELECTOR,
+            'ul.select2-results__options li.select2-results__option',
+        )

--- a/integration_tests/suite/test_authentication.py
+++ b/integration_tests/suite/test_authentication.py
@@ -1,8 +1,9 @@
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, contains_string, equal_to, not_, calling, raises
 from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
 
 from .helpers.base import IntegrationTest
 from .helpers.constants import USERNAME_PASSWORD_ERROR
@@ -20,7 +21,7 @@ class TestLogin(IntegrationTest):
         login.fill_name('username', '')
         login.fill_name('password', '')
 
-        submit = login.driver.find_element_by_id('submit')
+        submit = login.driver.find_element(By.ID, 'submit')
         assert_that(submit.get_attribute('class'), contains_string('disabled'))
 
         login.save(waiting=False)
@@ -36,7 +37,7 @@ class TestLogin(IntegrationTest):
         login.fill_name('username', 'test')
         login.fill_name('password', 'foobar')
 
-        submit = login.driver.find_element_by_id('submit')
+        submit = login.driver.find_element(By.ID, 'submit')
         assert_that(submit.get_attribute('class'), not_(contains_string('disabled')))
 
         login.save(waiting=False)


### PR DESCRIPTION
## Fix selenium deprecated find_element_by_* usage

why: this method was removed in selenium 4.3.0

## tests: avoid mixing single/double quote in same file