### PR TITLE
ha: fix bad error handling on POST

### DIFF
--- a/wazo_ui/plugins/ha/view.py
+++ b/wazo_ui/plugins/ha/view.py
@@ -37,7 +37,7 @@ class HaView(BaseIPBXHelperView):
         form = self.form()
         if not form.csrf_token.validate(form):
             self._flash_basic_form_errors(form)
-            return self._index(form)
+            return self.index()
 
         resource = form.to_dict()
 


### PR DESCRIPTION
why: self._index will trigger service.list(), which doesn't exist for HA
form. Using this fix will make the all data lost, but it's a good tradeoff
for this form (which has only 2 inputs)