### PR TITLE
phonebook: force the ID field to be used

### DIFF
--- a/wazo_ui/plugins/phonebook/templates/wazo_engine/phonebook/list.html
+++ b/wazo_ui/plugins/phonebook/templates/wazo_engine/phonebook/list.html
@@ -14,7 +14,7 @@
           <th>{{ _('Name') }}</th>
           <th>{{ _('Description') }}</th>
         {% endcall %}
-        {% call(phonebook) build_list_table_rows(resource_list['items']) %}
+        {% call(phonebook) build_list_table_rows(resource_list['items'], id_field='id') %}
           <td>{{ phonebook.name }}</td>
           <td>{{ phonebook.description or '-' }}</td>
         {% endcall %}

--- a/wazo_ui/templates/macro.html
+++ b/wazo_ui/templates/macro.html
@@ -334,12 +334,12 @@
 {% endmacro %}
 
 
-{% macro build_list_table_rows(items, non_unique_id=false) %}
+{% macro build_list_table_rows(items, non_unique_id=false, id_field='') %}
   {% set caller_ = caller %}
   {% call build_table_body() %}
     {% for item in items %}
       {% set editable = false if item.editable == False else true %}
-      <tr{{ ' data-id=' ~ item.id if item.id }}{{ ' data-uuid=' ~ item.uuid if item.uuid }}{{ ' data-tenant-uuid=' ~ item.tenant_uuid if item.tenant_uuid }}{{ ' data-non-unique-id=' ~ non_unique_id if non_unique_id }}{{ ' data-get_url=' ~ item.get_url if item.get_url }} data-editable="{{ editable }}">
+      <tr{% if not id_field or id_field == 'id' %}{{ ' data-id=' ~ item.id if item.id }}{% endif %}{% if not id_field or id_field == 'uuid' %}{{ ' data-uuid=' ~ item.uuid if item.uuid }}{% endif %}{{ ' data-tenant-uuid=' ~ item.tenant_uuid if item.tenant_uuid }}{{ ' data-non-unique-id=' ~ non_unique_id if non_unique_id }}{{ ' data-get_url=' ~ item.get_url if item.get_url }} data-editable="{{ editable }}">
         {{ caller_(item) }}
       </tr>
     {% endfor %}


### PR DESCRIPTION
the phonebook has a new API and now exposes a UUID. Since the UUID is now port of the list payload wazo-ui tries to use the old API with the UUID but dird does not implement that route with a UUID argument and will never do so.

this change forces the ID field to be used until wazo-ui gets modified to use the new API