### PR TITLE
Pull request for WAZO-3768-small-queue-improvement

### DIFF
--- a/wazo_ui/plugins/queue/form.py
+++ b/wazo_ui/plugins/queue/form.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask_babel import lazy_gettext as l_
@@ -64,7 +64,7 @@ class MembersForm(BaseForm):
 
 class QueueForm(BaseForm):
     name = StringField(l_('Name'), [InputRequired(), Length(max=128)])
-    label = StringField(l_('Label'), [InputRequired(), Length(max=128)])
+    label = StringField(l_('Label'), [Length(max=128)])
 
     announce_hold_time_on_entry = BooleanField(
         l_('Announce hold time on entry'), default=False

--- a/wazo_ui/plugins/queue/templates/wazo_engine/queue/edit.html
+++ b/wazo_ui/plugins/queue/templates/wazo_engine/queue/edit.html
@@ -26,7 +26,7 @@
 
           {% call build_tab_content_item('general', active=True) %}
             {% call add_default_fields(form=form, submit_value=_('Update')) %}
-              {{ render_field(form.name) }}
+              {{ render_field(form.name, readonly='readonly') }}
               {{ render_field(form.extensions[0].context,
                               label='Exten',
                               inputclass='ui-helper-clearfix',

--- a/wazo_ui/plugins/queue/templates/wazo_engine/queue/edit.html
+++ b/wazo_ui/plugins/queue/templates/wazo_engine/queue/edit.html
@@ -27,6 +27,7 @@
           {% call build_tab_content_item('general', active=True) %}
             {% call add_default_fields(form=form, submit_value=_('Update')) %}
               {{ render_field(form.name, readonly='readonly') }}
+              {{ render_field(form.label) }}
               {{ render_field(form.extensions[0].context,
                               label='Exten',
                               inputclass='ui-helper-clearfix',

--- a/wazo_ui/plugins/queue/templates/wazo_engine/queue/list.html
+++ b/wazo_ui/plugins/queue/templates/wazo_engine/queue/list.html
@@ -35,6 +35,7 @@
       {% call build_form() %}
         {% call add_default_fields(form=form, submit_value=_('Add')) %}
           {{ render_field(form.name) }}
+          {{ render_field(form.label) }}
           {{ render_field(form.extensions[0].context,
                           inputclass='ui-helper-clearfix',
                           divclass='col-sm-4',


### PR DESCRIPTION
## queue: make name not editable

why: API does not allow to edit name after creation

## queue: expose label in create and edit form

why: this label is used when listing incall with destination

## queue: make label not required

why: API allow to use null