### PR TITLE
pytest: migrate setup.cfg conf to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,6 @@ exclude = [
 [tool.isort]
 profile = "black"
 py_version = 311
+
+[tool.pytest]
+testpaths = ["wazo_ui"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[tool:pytest]
-testpaths=wazo_ui
-
 [compile_catalog]
 directory=wazo_ui/translations
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
 pyhamcrest
-pytest
+pytest>=9.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Move pytest config from setup.cfg to pyproject.toml and bump pytest to >=9.0.
> 
> - **Testing/Tooling**:
>   - **Pytest config**: Migrate to `pyproject.toml` under `[tool.pytest]` with `testpaths=["wazo_ui"]`; remove from `setup.cfg`.
>   - **Dependencies**: Update `test-requirements.txt` to `pytest>=9.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd036f06196770cfb06730885b988d6f266e2c50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->