### PR TITLE
WAZO-4352: Force json when decoding requests content

### DIFF
--- a/wazo_ui/plugins/phone_number/view.py
+++ b/wazo_ui/plugins/phone_number/view.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2024-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import jsonify, request
@@ -50,6 +50,6 @@ class PhoneNumberView(BaseIPBXHelperView):
 
     @route('/select_main_number/', methods=['POST'])
     def select_main_number(self):
-        body = request.get_json()
+        body = request.get_json(force=True)
         self.service.select_main_number(body['number_uuid'])
         return jsonify(body)

--- a/wazo_ui/plugins/plugin/view.py
+++ b/wazo_ui/plugins/plugin/view.py
@@ -19,19 +19,19 @@ class PluginView(LoginRequiredView):
 
     @route('/install_plugin/', methods=['POST'])
     def install_plugin(self):
-        body = request.get_json()
+        body = request.get_json(force=True)
         plugin = self.service.install(body)
         return jsonify(plugin)
 
     @route('/remove_plugin/', methods=['POST'])
     def remove_plugin(self):
-        body = request.get_json()
+        body = request.get_json(force=True)
         plugin = self.service.uninstall(body)
         return jsonify(plugin)
 
     @route('/search_plugin/', methods=['POST'])
     def search_plugin(self):
-        payload = request.get_json()
+        payload = request.get_json(force=True)
         search = payload.get('search')
         namespace = payload.get('namespace')
         installed = payload.get('installed')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures POST handlers consistently parse JSON bodies.
> 
> - Use `request.get_json(force=True)` in `select_main_number`, `install_plugin`, `remove_plugin`, and `search_plugin` endpoints
> - Update copyright year in `phone_number/view.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 851e6619d1e2a71558c785232c9658872f8ecb13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->