### PR TITLE
[ITEM-205] funckey: remove calllistening destination

### DIFF
--- a/wazo_ui/plugins/funckey/form.py
+++ b/wazo_ui/plugins/funckey/form.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask_babel import lazy_gettext as l_
@@ -24,7 +24,6 @@ class GeneralServicesFuncKeyDestinationForm(BaseForm):
             ('phonestatus', l_('Phone status')),
             ('recsnd', l_('Sound recording')),
             ('fwdundoall', l_('Disable all forwarding')),
-            ('calllistening', l_('Listen to online calls')),
             ('directoryaccess', l_('Directory access')),
             ('pickup', l_('Group Interception')),
             ('callrecord', l_('Call recording')),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/form change that only removes a selectable destination option; no authentication or data-processing logic is modified.
> 
> **Overview**
> Removes the `calllistening` destination from the `GeneralServicesFuncKeyDestinationForm` service choices so it can no longer be selected/configured via the UI.
> 
> Also updates the copyright header year range in `wazo_ui/plugins/funckey/form.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8252fd65e94dc7a6ecc6af0e53bfb0110f31ad3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->