### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/etc/wazo-ui/config.yml
+++ b/etc/wazo-ui/config.yml
@@ -24,8 +24,7 @@
 #
 # auth:
 #   host: localhost
-#   port: 9497
-#   prefix: None
+#   port: 80
 #   https: false
 #
 # call-logd:

--- a/integration_tests/assets/etc/wazo-ui/conf.d/default.yml
+++ b/integration_tests/assets/etc/wazo-ui/conf.d/default.yml
@@ -2,3 +2,5 @@ http:
   listen: 0.0.0.0
 auth:
   host: auth
+  port: 9497
+  prefix: null

--- a/wazo_ui/config.py
+++ b/wazo_ui/config.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -28,8 +28,7 @@ _DEFAULT_CONFIG = {
     },
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
     },
     'call-logd': {

--- a/wazo_ui/plugins/dird_source/view.py
+++ b/wazo_ui/plugins/dird_source/view.py
@@ -105,12 +105,7 @@ class DirdSourceView(BaseIPBXHelperView):
                 'timeout': 10,
             },
             'office365_config': {
-                'auth': {
-                    'port': 80,
-                    'timeout': 0,
-                    'verify_certificate': True,
-                    'version': '0.1',
-                },
+                'auth': default_auth_config,
                 'endpoint': 'https://graph.microsoft.com/v1.0/me/contacts',
             },
             'google_config': {

--- a/wazo_ui/plugins/dird_source/view.py
+++ b/wazo_ui/plugins/dird_source/view.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -56,9 +56,9 @@ class DirdSourceView(BaseIPBXHelperView):
     def new(self, backend):
         default_auth_config = {
             'host': 'localhost',
-            'port': 9497,
+            'port': 80,
             'timeout': '',
-            'prefix_': None,
+            'prefix_': '/api/auth',
             'https': False,
             'verify_certificate': False,
             'certificate_path': '',
@@ -106,7 +106,7 @@ class DirdSourceView(BaseIPBXHelperView):
             },
             'office365_config': {
                 'auth': {
-                    'port': 9497,
+                    'port': 80,
                     'timeout': 0,
                     'verify_certificate': True,
                     'version': '0.1',


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

Notes:

* Integration test assets now pin `port: 9497` and `prefix: null` explicitly:
  their stacks have no nginx, and those values used to come from the defaults
  changed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all internal authentication traffic is reached and depends on coordinated nginx/auth deployment; mis-timed rollout breaks login and auth-backed features.
> 
> **Overview**
> Internal **wazo-auth** calls from wazo-ui now target **nginx on `localhost:80`** instead of the wazo-auth process port **9497**, in Python defaults and the shipped example `config.yml`. The explicit **`auth.prefix`** default is removed so **`wazo-auth-client`**’s built-in **`/api/auth`** path applies.
> 
> **DIRd source** “new source” form defaults are aligned: auth **port 80**, **`prefix_` `/api/auth`**, and Office365 reuses the shared `default_auth_config` instead of a separate 9497 block.
> 
> Integration test config **pins `port: 9497` and `prefix: null`** because those stacks have no nginx and previously inherited the old defaults.
> 
> **Deploy order:** requires the nginx internal entry and wazo-auth location from dependent PRs; merging early breaks internal auth (404).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfc9e18e793f2af83b4feb1fe0aacfa7c8178a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->